### PR TITLE
Revive team pages 10

### DIFF
--- a/aleksandr.html
+++ b/aleksandr.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="scprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/altinak.html
+++ b/altinak.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="robprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/arcturus.html
+++ b/arcturus.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="rprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/aurelius.html
+++ b/aurelius.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="rprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/consat-1.html
+++ b/consat-1.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="scprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/contact.html
+++ b/contact.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="contact.css">
     <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
     <link rel="shortcut icon" type="image/png" href="/favicon.png">
+    <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/donate.html
+++ b/donate.html
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="donate.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+    <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/exec.html
+++ b/exec.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="exec.css">
     <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
     <link rel="shortcut icon" type="image/png" href="/favicon.png">
+    <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/expandableLinks.js
+++ b/expandableLinks.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", function() {
 	lists[3].classList.add('projects-btn-js');
 	lists[4].classList.add('contact-btn-js');
 
-		// get nav buttons
+	// get nav buttons
 	var spaceCraftBtn = document.querySelectorAll('.spacecraft-btn-js')[0];
 	var rocketryBtn = document.querySelectorAll('.rocketry-btn-js')[0];
 	var projectsBtn = document.querySelectorAll('.projects-btn-js')[0];

--- a/expandableLinks.js
+++ b/expandableLinks.js
@@ -5,38 +5,44 @@
 
 document.addEventListener("DOMContentLoaded", function() {
 	var lists = document.querySelectorAll('li.dropdown')
+	lists[0].classList.add('about-btn-js');
 	lists[1].classList.add('spacecraft-btn-js');
 	lists[2].classList.add('rocketry-btn-js');
 	lists[3].classList.add('projects-btn-js');
 	lists[4].classList.add('contact-btn-js');
 
 	// get nav buttons
-	var spaceCraftBtn = document.querySelectorAll('.spacecraft-btn-js')[0];
-	var rocketryBtn = document.querySelectorAll('.rocketry-btn-js')[0];
-	var projectsBtn = document.querySelectorAll('.projects-btn-js')[0];
-	var contactBtn = document.querySelectorAll('.contact-btn-js')[0];
+	var aboutBtn 		= document.querySelectorAll('.about-btn-js')[0];
+	var spaceCraftBtn 	= document.querySelectorAll('.spacecraft-btn-js')[0];
+	var rocketryBtn 	= document.querySelectorAll('.rocketry-btn-js')[0];
+	var projectsBtn 	= document.querySelectorAll('.projects-btn-js')[0];
+	var contactBtn 		= document.querySelectorAll('.contact-btn-js')[0];
 
 	// event handler functions
+	var navigateToAbout = function () {
+		window.location.href = 'index.html';
+	}
 	var navigateToSpaceCraft = function() {
-		window.location.href = "spacecraft.html";
+		window.location.href = 'spacecraft.html';
 	}
 
 	var navigateToRocketry = function() {
-		window.location.href = "rocketry.html";
+		window.location.href = 'rocketry.html';
 	}
 
 	var navigateToProjects = function() {
-		window.location.href = "projects.html";
+		window.location.href = 'projects.html';
 	}
 
 	var navigateToContact = function() {
-		window.location.href = "contact.html";
+		window.location.href = 'contact.html';
 	}
 
 	// bind listeners to dropdown button hybrids
-	spaceCraftBtn.onclick = navigateToSpaceCraft;
-	rocketryBtn.onclick = navigateToRocketry;
-	projectsBtn.onclick = navigateToProjects;
-	contactBtn.onclick = navigateToContact;
+	aboutBtn.onclick 		= navigateToAbout;
+	spaceCraftBtn.onclick 	= navigateToSpaceCraft;
+	rocketryBtn.onclick 	= navigateToRocketry;
+	projectsBtn.onclick 	= navigateToProjects;
+	contactBtn.onclick 		= navigateToContact;
 });
 

--- a/expandableLinks.js
+++ b/expandableLinks.js
@@ -1,0 +1,42 @@
+/**
+  * This script is meant to make the parent <li> tags in the navbar 
+  * which are expandable, also behave as links
+  */
+
+document.addEventListener("DOMContentLoaded", function() {
+	var lists = document.querySelectorAll('li.dropdown')
+	lists[1].classList.add('spacecraft-btn-js');
+	lists[2].classList.add('rocketry-btn-js');
+	lists[3].classList.add('projects-btn-js');
+	lists[4].classList.add('contact-btn-js');
+
+		// get nav buttons
+	var spaceCraftBtn = document.querySelectorAll('.spacecraft-btn-js')[0];
+	var rocketryBtn = document.querySelectorAll('.rocketry-btn-js')[0];
+	var projectsBtn = document.querySelectorAll('.projects-btn-js')[0];
+	var contactBtn = document.querySelectorAll('.contact-btn-js')[0];
+
+	// event handler functions
+	var navigateToSpaceCraft = function() {
+		window.location.href = "spacecraft.html";
+	}
+
+	var navigateToRocketry = function() {
+		window.location.href = "rocketry.html";
+	}
+
+	var navigateToProjects = function() {
+		window.location.href = "projects.html";
+	}
+
+	var navigateToContact = function() {
+		window.location.href = "contact.html";
+	}
+
+	// bind listeners to dropdown button hybrids
+	spaceCraftBtn.onclick = navigateToSpaceCraft;
+	rocketryBtn.onclick = navigateToRocketry;
+	projectsBtn.onclick = navigateToProjects;
+	contactBtn.onclick = navigateToContact;
+});
+

--- a/faq.html
+++ b/faq.html
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="faq.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+    <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/groundsegment.html
+++ b/groundsegment.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="scprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/history.html
+++ b/history.html
@@ -12,6 +12,7 @@
 	<link href="history.css" rel="stylesheet">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+	<script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 	<link rel="stylesheet" href="styles.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<script src="smoothscrolling.js"></script>
+    <script src="expandableLinks.js"></script>
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
 </head>
 

--- a/join.html
+++ b/join.html
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="join.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+	<script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/mission.html
+++ b/mission.html
@@ -12,6 +12,7 @@
 	<link href="mission.css" rel="stylesheet">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+	<script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/opensource.html
+++ b/opensource.html
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="opensource.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+	<script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/projects.html
+++ b/projects.html
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="projects.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+	<script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/robotics.html
+++ b/robotics.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="robotics.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/rocketry.html
+++ b/rocketry.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="rocketry.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/scaar.html
+++ b/scaar.html
@@ -12,6 +12,7 @@
      <link rel="stylesheet" href="robprojects.css">
      <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
      <link rel="shortcut icon" type="image/png" href="/favicon.png">
+     <script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/spacecraft.html
+++ b/spacecraft.html
@@ -12,6 +12,7 @@
 	<link rel="stylesheet" href="spacecraft.css">
 	<link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
+	<script src="expandableLinks.js"></script>
 </head>
 
 <body>

--- a/sponsors.html
+++ b/sponsors.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="sponsors.css">
   <link rel="stylesheet" href="font-awesome/css/font-awesome.min.css">
   <link rel="shortcut icon" type="image/png" href="/favicon.png">
+  <script src="expandableLinks.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR resolves issue #10, which didn't mention that Contact Us page navbar-dropdown/link was also kaput. Now navbar dropdown menu labels (actually `li` elements) behave as links as well, swell!

## The problem (general)
It seems that if you have nested lists and if the parent `li` is behaving as a drop down menu, they cannot behave both as a drop down menu and as a link (at least to the extend of my knowledge atm).

## The solution (approach)
To avoid having to manually add new classes in 21 html files, `expandableLinks.js` adds specific classes to those parent `li`s, get's ~~the ones we want (4/5 of them)~~ all 5 of them and then binds click event listeners to them. 
The handler functions for these click events simply navigate the current page over to the appropriate page by the power of `window.location.href`.

I left the `href` attributes with their values in the `a` tags there because I hope that if there is a cleaner solution maybe someone else can implement it (and still see what was broken). Also there's 21*4 instances I'd have to manually delete them... thanks but no thanks :)

